### PR TITLE
Fix the parsing issue of preprocessing macros within the module's port declarations.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -488,6 +488,7 @@ const rules = {
   list_of_port_declarations: $ => seq(
     '(',
     commaSep(seq(
+      optional($.conditional_compilation_directive), // New option, Out of LRM
       repeat($.attribute_instance),
       $.ansi_port_declaration)
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2115,6 +2115,18 @@
                   "type": "SEQ",
                   "members": [
                     {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "conditional_compilation_directive"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
                       "type": "REPEAT",
                       "content": {
                         "type": "SYMBOL",
@@ -2139,6 +2151,18 @@
                       {
                         "type": "SEQ",
                         "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "conditional_compilation_directive"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
                           {
                             "type": "REPEAT",
                             "content": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8335,6 +8335,10 @@
         {
           "type": "attribute_instance",
           "named": true
+        },
+        {
+          "type": "conditional_compilation_directive",
+          "named": true
         }
       ]
     }

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/test/corpus/core/directives/module_port_list.txt
+++ b/test/corpus/core/directives/module_port_list.txt
@@ -1,0 +1,68 @@
+============================================
+core/directives/module_port_list
+============================================
+
+module test(
+	input port_a,
+`ifdef FOO
+	input port_b,
+`endif
+
+	output port_c
+);
+	
+`ifdef FOO
+	assign port_c = port_b;
+`else
+	assign port_c = port_a;
+`endif
+
+endmodule: test
+----
+
+(source_file
+      (module_declaration
+        (module_ansi_header
+          (module_keyword)
+          name: (simple_identifier)
+          (list_of_port_declarations
+            (ansi_port_declaration
+              (net_port_header
+                (port_direction))
+              port_name: (simple_identifier))
+            (conditional_compilation_directive
+              (ifdef_condition
+                (simple_identifier)))
+            (ansi_port_declaration
+              (net_port_header
+                (port_direction))
+              port_name: (simple_identifier))
+            (conditional_compilation_directive)
+            (ansi_port_declaration
+              (net_port_header
+                (port_direction))
+              port_name: (simple_identifier))))
+        (conditional_compilation_directive
+          (ifdef_condition
+            (simple_identifier)))
+        (continuous_assign
+          (list_of_net_assignments
+            (net_assignment
+              (net_lvalue
+                (simple_identifier))
+              (expression
+                (primary
+                  (hierarchical_identifier
+                    (simple_identifier)))))))
+        (conditional_compilation_directive)
+        (continuous_assign
+          (list_of_net_assignments
+            (net_assignment
+              (net_lvalue
+                (simple_identifier))
+              (expression
+                (primary
+                  (hierarchical_identifier
+                    (simple_identifier)))))))
+        (conditional_compilation_directive)
+        (simple_identifier)))

--- a/test/files/core/directives/module_port_list.sv
+++ b/test/files/core/directives/module_port_list.sv
@@ -1,0 +1,16 @@
+module test(
+	input port_a,
+`ifdef FOO
+	input port_b,
+`endif
+
+	output port_c
+);
+	
+`ifdef FOO
+	assign port_c = port_b;
+`else
+	assign port_c = port_a;
+`endif
+
+endmodule: test


### PR DESCRIPTION
Fix In SystemVerilog, macro definition parsing error #13