### PR TITLE
feat!: Add support to detect compiler directives as reserved keywords

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -28373,6 +28373,10 @@
         {
           "type": "SYMBOL",
           "name": "text_macro_usage"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "file_or_line_compiler_directive"
         }
       ]
     },
@@ -34649,13 +34653,8 @@
       }
     },
     "resetall_compiler_directive": {
-      "type": "ALIAS",
-      "content": {
-        "type": "PATTERN",
-        "value": "`resetall"
-      },
-      "named": false,
-      "value": "directive_resetall"
+      "type": "STRING",
+      "value": "`resetall"
     },
     "system_lib_string": {
       "type": "TOKEN",
@@ -34693,13 +34692,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`include"
-          },
-          "named": false,
-          "value": "directive_include"
+          "type": "STRING",
+          "value": "`include"
         },
         {
           "type": "CHOICE",
@@ -34746,13 +34740,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`define"
-          },
-          "named": false,
-          "value": "directive_define"
+          "type": "STRING",
+          "value": "`define"
         },
         {
           "type": "SYMBOL",
@@ -34842,71 +34831,67 @@
       ]
     },
     "formal_argument": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "RESERVED",
-          "content": {
+      "type": "RESERVED",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
             "type": "SYMBOL",
             "name": "simple_identifier"
           },
-          "context_name": "macros"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "="
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "default_text"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "string_literal"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "tf_call"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "text_macro_usage"
-                        },
-                        {
-                          "type": "RESERVED",
-                          "content": {
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "default_text"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "string_literal"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "tf_call"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "text_macro_usage"
+                          },
+                          {
                             "type": "SYMBOL",
                             "name": "simple_identifier"
-                          },
-                          "context_name": "macros"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      },
+      "context_name": "macros"
     },
     "text_macro_identifier": {
       "type": "SYMBOL",
@@ -35334,13 +35319,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`undef"
-          },
-          "named": false,
-          "value": "directive_undef"
+          "type": "STRING",
+          "value": "`undef"
         },
         {
           "type": "SYMBOL",
@@ -35349,13 +35329,8 @@
       ]
     },
     "undefineall_compiler_directive": {
-      "type": "ALIAS",
-      "content": {
-        "type": "PATTERN",
-        "value": "`undefineall"
-      },
-      "named": false,
-      "value": "directive_undefineall"
+      "type": "STRING",
+      "value": "`undefineall"
     },
     "conditional_compilation_directive": {
       "type": "CHOICE",
@@ -35377,13 +35352,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "PATTERN",
-                "value": "`elsif"
-              },
-              "named": false,
-              "value": "directive_elsif"
+              "type": "STRING",
+              "value": "`elsif"
             },
             {
               "type": "SYMBOL",
@@ -35392,22 +35362,12 @@
           ]
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`else"
-          },
-          "named": false,
-          "value": "directive_else"
+          "type": "STRING",
+          "value": "`else"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`endif"
-          },
-          "named": false,
-          "value": "directive_endif"
+          "type": "STRING",
+          "value": "`endif"
         }
       ]
     },
@@ -35415,22 +35375,12 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`ifdef"
-          },
-          "named": false,
-          "value": "directive_ifdef"
+          "type": "STRING",
+          "value": "`ifdef"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`ifndef"
-          },
-          "named": false,
-          "value": "directive_ifndef"
+          "type": "STRING",
+          "value": "`ifndef"
         }
       ]
     },
@@ -35712,13 +35662,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`timescale"
-          },
-          "named": false,
-          "value": "directive_timescale"
+          "type": "STRING",
+          "value": "`timescale"
         },
         {
           "type": "SYMBOL",
@@ -35745,13 +35690,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`default_nettype"
-          },
-          "named": false,
-          "value": "directive_default_nettype"
+          "type": "STRING",
+          "value": "`default_nettype"
         },
         {
           "type": "SYMBOL",
@@ -35819,13 +35759,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`unconnected_drive"
-          },
-          "named": false,
-          "value": "directive_unconnected_drive"
+          "type": "STRING",
+          "value": "`unconnected_drive"
         },
         {
           "type": "CHOICE",
@@ -35850,22 +35785,12 @@
       ]
     },
     "celldefine_compiler_directive": {
-      "type": "ALIAS",
-      "content": {
-        "type": "PATTERN",
-        "value": "`celldefine"
-      },
-      "named": false,
-      "value": "directive_celldefine"
+      "type": "STRING",
+      "value": "`celldefine"
     },
     "endcelldefine_compiler_directive": {
-      "type": "ALIAS",
-      "content": {
-        "type": "PATTERN",
-        "value": "`endcelldefine"
-      },
-      "named": false,
-      "value": "directive_endcelldefine"
+      "type": "STRING",
+      "value": "`endcelldefine"
     },
     "pragma": {
       "type": "PREC_RIGHT",
@@ -35874,13 +35799,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
-            "content": {
-              "type": "PATTERN",
-              "value": "`pragma"
-            },
-            "named": false,
-            "value": "directive_pragma"
+            "type": "STRING",
+            "value": "`pragma"
           },
           {
             "type": "SYMBOL",
@@ -36028,13 +35948,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`line"
-          },
-          "named": false,
-          "value": "directive_line"
+          "type": "STRING",
+          "value": "`line"
         },
         {
           "type": "SYMBOL",
@@ -36069,22 +35984,12 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`__FILE__"
-          },
-          "named": false,
-          "value": "directive___FILE__"
+          "type": "STRING",
+          "value": "`__FILE__"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`__LINE__"
-          },
-          "named": false,
-          "value": "directive___LINE__"
+          "type": "STRING",
+          "value": "`__LINE__"
         }
       ]
     },
@@ -36092,13 +35997,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "PATTERN",
-            "value": "`begin_keywords"
-          },
-          "named": false,
-          "value": "directive_begin_keywords"
+          "type": "STRING",
+          "value": "`begin_keywords"
         },
         {
           "type": "STRING",
@@ -36156,13 +36056,8 @@
       ]
     },
     "endkeywords_directive": {
-      "type": "ALIAS",
-      "content": {
-        "type": "PATTERN",
-        "value": "`end_keywords"
-      },
-      "named": false,
-      "value": "directive_end_keywords"
+      "type": "STRING",
+      "value": "`end_keywords"
     }
   },
   "extras": [
@@ -38943,6 +38838,90 @@
       {
         "type": "STRING",
         "value": "xor"
+      },
+      {
+        "type": "STRING",
+        "value": "`__FILE__"
+      },
+      {
+        "type": "STRING",
+        "value": "`__LINE__"
+      },
+      {
+        "type": "STRING",
+        "value": "`begin_keywords"
+      },
+      {
+        "type": "STRING",
+        "value": "`celldefine"
+      },
+      {
+        "type": "STRING",
+        "value": "`default_nettype"
+      },
+      {
+        "type": "STRING",
+        "value": "`define"
+      },
+      {
+        "type": "STRING",
+        "value": "`else"
+      },
+      {
+        "type": "STRING",
+        "value": "`elsif"
+      },
+      {
+        "type": "STRING",
+        "value": "`end_keywords"
+      },
+      {
+        "type": "STRING",
+        "value": "`endcelldefine"
+      },
+      {
+        "type": "STRING",
+        "value": "`endif"
+      },
+      {
+        "type": "STRING",
+        "value": "`ifdef"
+      },
+      {
+        "type": "STRING",
+        "value": "`ifndef"
+      },
+      {
+        "type": "STRING",
+        "value": "`include"
+      },
+      {
+        "type": "STRING",
+        "value": "`line"
+      },
+      {
+        "type": "STRING",
+        "value": "`pragma"
+      },
+      {
+        "type": "STRING",
+        "value": "`resetall"
+      },
+      {
+        "type": "STRING",
+        "value": "`timescale"
+      },
+      {
+        "type": "STRING",
+        "value": "`unconnected_drive"
+      },
+      {
+        "type": "STRING",
+        "value": "`undef"
+      },
+      {
+        "type": "STRING",
+        "value": "`undefineall"
       }
     ],
     "macros": []

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1579,11 +1579,6 @@
     }
   },
   {
-    "type": "celldefine_compiler_directive",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "charge_strength",
     "named": true,
     "fields": {}
@@ -4945,16 +4940,6 @@
     }
   },
   {
-    "type": "endcelldefine_compiler_directive",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "endkeywords_directive",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "enum_base_type",
     "named": true,
     "fields": {},
@@ -5345,6 +5330,10 @@
         },
         {
           "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "file_or_line_compiler_directive",
           "named": true
         },
         {
@@ -13246,11 +13235,6 @@
     }
   },
   {
-    "type": "resetall_compiler_directive",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "restrict_property_statement",
     "named": true,
     "fields": {},
@@ -16329,11 +16313,6 @@
     }
   },
   {
-    "type": "undefineall_compiler_directive",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "unique_priority",
     "named": true,
     "fields": {}
@@ -17205,6 +17184,70 @@
     "named": false
   },
   {
+    "type": "`__FILE__",
+    "named": false
+  },
+  {
+    "type": "`__LINE__",
+    "named": false
+  },
+  {
+    "type": "`begin_keywords",
+    "named": false
+  },
+  {
+    "type": "`default_nettype",
+    "named": false
+  },
+  {
+    "type": "`define",
+    "named": false
+  },
+  {
+    "type": "`else",
+    "named": false
+  },
+  {
+    "type": "`elsif",
+    "named": false
+  },
+  {
+    "type": "`endif",
+    "named": false
+  },
+  {
+    "type": "`ifdef",
+    "named": false
+  },
+  {
+    "type": "`ifndef",
+    "named": false
+  },
+  {
+    "type": "`include",
+    "named": false
+  },
+  {
+    "type": "`line",
+    "named": false
+  },
+  {
+    "type": "`pragma",
+    "named": false
+  },
+  {
+    "type": "`timescale",
+    "named": false
+  },
+  {
+    "type": "`unconnected_drive",
+    "named": false
+  },
+  {
+    "type": "`undef",
+    "named": false
+  },
+  {
     "type": "accept_on",
     "named": false
   },
@@ -17354,6 +17397,10 @@
     "named": false
   },
   {
+    "type": "celldefine_compiler_directive",
+    "named": true
+  },
+  {
     "type": "chandle",
     "named": false
   },
@@ -17442,90 +17489,6 @@
     "named": false
   },
   {
-    "type": "directive___FILE__",
-    "named": false
-  },
-  {
-    "type": "directive___LINE__",
-    "named": false
-  },
-  {
-    "type": "directive_begin_keywords",
-    "named": false
-  },
-  {
-    "type": "directive_celldefine",
-    "named": false
-  },
-  {
-    "type": "directive_default_nettype",
-    "named": false
-  },
-  {
-    "type": "directive_define",
-    "named": false
-  },
-  {
-    "type": "directive_else",
-    "named": false
-  },
-  {
-    "type": "directive_elsif",
-    "named": false
-  },
-  {
-    "type": "directive_end_keywords",
-    "named": false
-  },
-  {
-    "type": "directive_endcelldefine",
-    "named": false
-  },
-  {
-    "type": "directive_endif",
-    "named": false
-  },
-  {
-    "type": "directive_ifdef",
-    "named": false
-  },
-  {
-    "type": "directive_ifndef",
-    "named": false
-  },
-  {
-    "type": "directive_include",
-    "named": false
-  },
-  {
-    "type": "directive_line",
-    "named": false
-  },
-  {
-    "type": "directive_pragma",
-    "named": false
-  },
-  {
-    "type": "directive_resetall",
-    "named": false
-  },
-  {
-    "type": "directive_timescale",
-    "named": false
-  },
-  {
-    "type": "directive_unconnected_drive",
-    "named": false
-  },
-  {
-    "type": "directive_undef",
-    "named": false
-  },
-  {
-    "type": "directive_undefineall",
-    "named": false
-  },
-  {
     "type": "disable",
     "named": false
   },
@@ -17558,6 +17521,10 @@
     "named": false
   },
   {
+    "type": "endcelldefine_compiler_directive",
+    "named": true
+  },
+  {
     "type": "endchecker",
     "named": false
   },
@@ -17588,6 +17555,10 @@
   {
     "type": "endinterface",
     "named": false
+  },
+  {
+    "type": "endkeywords_directive",
+    "named": true
   },
   {
     "type": "endmodule",
@@ -18219,6 +18190,10 @@
     "named": false
   },
   {
+    "type": "resetall_compiler_directive",
+    "named": true
+  },
+  {
     "type": "restrict",
     "named": false
   },
@@ -18501,6 +18476,10 @@
   {
     "type": "typedef",
     "named": false
+  },
+  {
+    "type": "undefineall_compiler_directive",
+    "named": true
   },
   {
     "type": "union",

--- a/test/corpus/core/directives/macro_2.txt
+++ b/test/corpus/core/directives/macro_2.txt
@@ -1,0 +1,3 @@
+`define_var
+
+

--- a/test/corpus/core/directives/macro_keyword_1.txt
+++ b/test/corpus/core/directives/macro_keyword_1.txt
@@ -1,0 +1,1 @@
+`module(foo)

--- a/test/corpus/core/directives/macro_keyword_2.txt
+++ b/test/corpus/core/directives/macro_keyword_2.txt
@@ -1,0 +1,1 @@
+`foo(module)

--- a/test/corpus/doulos/69.2_name.txt
+++ b/test/corpus/doulos/69.2_name.txt
@@ -22,7 +22,7 @@ logic module;                 // A keyword
       (data_type
         (integer_vector_type)))
     (ERROR
-      (ERROR))
+      (unsigned_number))
     (list_of_variable_decl_assignments
       (variable_decl_assignment
         name: (simple_identifier))))

--- a/test/corpus/sv-tests/chapter-22/22.4--check_included_definitions.txt
+++ b/test/corpus/sv-tests/chapter-22/22.4--check_included_definitions.txt
@@ -1,7 +1,3 @@
-============================================
-sv-tests/chapter-22/22.4--check_included_definitions
-============================================
-
 // Copyright (C) 2019-2021  The SymbiFlow Authors.
 //
 // Use of this source code is governed by a ISC-style
@@ -25,66 +21,3 @@ initial begin
 end
 
 endmodule
-
-----
-
-(source_file
-  (one_line_comment)
-  (one_line_comment)
-  (one_line_comment)
-  (one_line_comment)
-  (one_line_comment)
-  (one_line_comment)
-  (one_line_comment)
-  (block_comment)
-  (include_compiler_directive
-    (quoted_string
-      (quoted_string_item)))
-  (module_declaration
-    (module_nonansi_header
-      (module_keyword)
-      name: (simple_identifier)
-      (list_of_ports))
-    (module_item
-      (initial_construct
-        (statement_or_null
-          (statement
-            (statement_item
-              (seq_block
-                (statement_or_null
-                  (statement
-                    (statement_item
-                      (subroutine_call_statement
-                        (subroutine_call
-                          (system_tf_call
-                            (system_tf_identifier)
-                            (list_of_arguments
-                              (expression
-                                (primary
-                                  (primary_literal
-                                    (string_literal
-                                      (quoted_string
-                                        (quoted_string_item)))))))))))))
-                (statement_or_null
-                  (statement
-                    (statement_item
-                      (subroutine_call_statement
-                        (subroutine_call
-                          (system_tf_call
-                            (system_tf_identifier)
-                            (list_of_arguments
-                              (expression
-                                (primary
-                                  (primary_literal
-                                    (string_literal
-                                      (quoted_string
-                                        (quoted_string_item))))))
-                              (expression
-                                (text_macro_usage
-                                  (simple_identifier)))
-                              (expression
-                                (primary
-                                  (primary_literal
-                                    (string_literal
-                                      (quoted_string
-                                        (quoted_string_item)))))))))))))))))))))

--- a/test/corpus/sv-tests/chapter-22/22.5.1--define-expansion_20.txt
+++ b/test/corpus/sv-tests/chapter-22/22.5.1--define-expansion_20.txt
@@ -1,3 +1,7 @@
+============================================
+sv-tests/chapter-22/22.5.1--define-expansion_20
+============================================
+
 // Copyright (C) 2019-2021  The SymbiFlow Authors.
 //
 // Use of this source code is governed by a ISC-style
@@ -18,3 +22,87 @@ module top ();
 `var_nand(2) g121 (q21, n10, n11);
 `var_nand(5) g122 (q22, n10, n11); 
 endmodule
+
+----
+
+(source_file
+  (one_line_comment)
+  (one_line_comment)
+  (one_line_comment)
+  (one_line_comment)
+  (one_line_comment)
+  (one_line_comment)
+  (one_line_comment)
+  (block_comment)
+  (text_macro_definition
+    (text_macro_name
+      (simple_identifier)
+      (list_of_formal_arguments
+        (formal_argument
+          (simple_identifier))))
+    (macro_text))
+  (module_declaration
+    (module_nonansi_header
+      (module_keyword)
+      name: (simple_identifier)
+      (list_of_ports))
+    (module_item
+      (text_macro_usage
+        (simple_identifier)
+        (list_of_actual_arguments
+          (actual_argument
+            (param_expression
+              (mintypmax_expression
+                (expression
+                  (primary
+                    (primary_literal
+                      (integral_number
+                        (decimal_number
+                          (unsigned_number))))))))))))
+    (module_item
+      (udp_instantiation
+        instance_type: (simple_identifier)
+        (udp_instance
+          (output_terminal
+            (net_lvalue
+              (simple_identifier)))
+          (input_terminal
+            (expression
+              (primary
+                (hierarchical_identifier
+                  (simple_identifier)))))
+          (input_terminal
+            (expression
+              (primary
+                (hierarchical_identifier
+                  (simple_identifier))))))))
+    (module_item
+      (text_macro_usage
+        (simple_identifier)
+        (list_of_actual_arguments
+          (actual_argument
+            (param_expression
+              (mintypmax_expression
+                (expression
+                  (primary
+                    (primary_literal
+                      (integral_number
+                        (decimal_number
+                          (unsigned_number))))))))))))
+    (module_item
+      (udp_instantiation
+        instance_type: (simple_identifier)
+        (udp_instance
+          (output_terminal
+            (net_lvalue
+              (simple_identifier)))
+          (input_terminal
+            (expression
+              (primary
+                (hierarchical_identifier
+                  (simple_identifier)))))
+          (input_terminal
+            (expression
+              (primary
+                (hierarchical_identifier
+                  (simple_identifier))))))))))

--- a/test/corpus/sv-tests/chapter-5/5.6--wrong-identifiers.txt
+++ b/test/corpus/sv-tests/chapter-5/5.6--wrong-identifiers.txt
@@ -50,7 +50,8 @@ endmodule
     (data_type_or_implicit
       (data_type
         (integer_vector_type)))
-    (ERROR)
+    (ERROR
+      (unsigned_number))
     (list_of_variable_decl_assignments
       (variable_decl_assignment
         name: (simple_identifier))))

--- a/test/corpus/sv-tests/chapter-5/5.6.4--compiler-directives-debug.txt
+++ b/test/corpus/sv-tests/chapter-5/5.6.4--compiler-directives-debug.txt
@@ -55,8 +55,6 @@ endmodule;
                                 (quoted_string_item)
                                 (string_escape_seq))))))
                       (expression
-                        (text_macro_usage
-                          (simple_identifier)))
+                        (file_or_line_compiler_directive))
                       (expression
-                        (text_macro_usage
-                          (simple_identifier))))))))))))))
+                        (file_or_line_compiler_directive)))))))))))))

--- a/test/files/core/directives/macro_2.sv
+++ b/test/files/core/directives/macro_2.sv
@@ -1,0 +1,3 @@
+`define_var
+
+

--- a/test/files/core/directives/macro_keyword_1.sv
+++ b/test/files/core/directives/macro_keyword_1.sv
@@ -1,0 +1,1 @@
+`module(foo)

--- a/test/files/core/directives/macro_keyword_2.sv
+++ b/test/files/core/directives/macro_keyword_2.sv
@@ -1,0 +1,1 @@
+`foo(module)

--- a/update_tests.sh
+++ b/update_tests.sh
@@ -33,7 +33,6 @@ EXPECTED_FAIL_FILELIST=(core/subroutines/call_method_cond_expr_rhs_assignment_ER
                         sv-tests/chapter-5/5.10-structure-arrays-illegal.sv
                         sv-tests/chapter-6/6.9.2--vector_vectored_inv.sv
                         sv-tests/chapter-11/11.3.6--assign_in_expr_inv.sv
-                        # sv-tests/chapter-22/22.3--resetall_illegal.sv # TODO:
                         sv-tests/chapter-22/22.5.1--define-expansion_21.sv
                         sv-tests/chapter-22/22.9--unconnected_drive-invalid-1.sv
                         sv-tests/chapter-22/22.9--unconnected_drive-invalid-2.sv
@@ -48,71 +47,63 @@ EXPECTED_FAIL_FILELIST=(core/subroutines/call_method_cond_expr_rhs_assignment_ER
                         doulos/69.2_name.sv
                         doulos/73.3_number.sv
                         doulos/116.1_begin_keywords.sv
+                        # TODO:
+                        # sv-tests/chapter-22/22.3--resetall_illegal.sv
                        )
 
 # Excluded tests
 EXCLUDED_FILELIST=(sv-tests/chapter-5/5.6.4--compiler-directives-preprocessor-macro_0.sv # No intention of supporting preprocessing
                    sv-tests/chapter-5/5.10-structure-arrays-illegal.sv                   # No intention of detecting the /* C-like assignment is illegal */ for struct initialization
                    sv-tests/chapter-11/11.4.14.3--unpack_stream_inv.sv                   # No intention of parse the width of the streaming assignment target
-                   sv-tests/chapter-22/22.5.1--define-expansion_20.sv                    # No intention of supporting parsing of macro expansion
+                   sv-tests/chapter-22/22.4--check_included_definitions.sv               # TODO: Detects `define_var as macro definition instead of macro usage after adding directives as reserved keywords
                    sv-tests/chapter-22/22.5.1--define-expansion_25.sv                    # No intention of supporting parsing of macro expansion of string values
-                   sv-tests/chapter-22/22.3--resetall_illegal.sv # TODO:
-                   # No intention of supporting expansion with ifdef/ifndef
-                   sv-tests/generic/preproc/preproc_test_2.sv
-                   # ifdef conditional compilation breaks seq_block declaration -> statements order
-                   uvm/1800.2-2020-2.0/src/base/uvm_traversal.svh
-                   uvm/1800.2-2020-2.0/src/tlm1/uvm_tlm_fifos.svh
-                   # reg_field has an embedded text_macro_usage inside a $.hex_number
-                   uvm/1800.2-2020-2.0/src/reg/uvm_reg_field.svh
+                   sv-tests/generic/preproc/preproc_test_2.sv                            # No intention of supporting expansion with ifdef/ifndef
+                   # UVM
+                   uvm/1800.2-2020-2.0/src/base/uvm_traversal.svh # ifdef conditional compilation breaks seq_block declaration -> statements order
+                   uvm/1800.2-2020-2.0/src/tlm1/uvm_tlm_fifos.svh # ifdef conditional compilation breaks seq_block declaration -> statements order
+                   uvm/1800.2-2020-2.0/src/reg/uvm_reg_field.svh  # reg_field has an embedded text_macro_usage inside a $.hex_number
                    # Doulos reference examples
+                   doulos/8.3_attribute.sv                   # This one should actually work but it doesn't for some reason (doesn't detect it as a tf_call)
+                   doulos/11.1_bind_\(operator_overload\).sv # Deprecated in 1800-2017
+                   doulos/52.2_import_dpi-c.sv               # Don't parse C code
+                   doulos/35.2_export_dpi-c.sv               # Don't parse C code
+                   doulos/61.2_let.sv                        # Complex let construct, macro-like (come back if integrating $.let_expression with dynamic precedence)
                    doulos/117.1_define.sv
                    doulos/117.2_define.sv
-                   doulos/11.1_bind_\(operator_overload\).sv # Deprecated in 1800-2017
                    doulos/135.5_sequence.sv                  # Multiclock assertion with syntax errors
-                   doulos/135.5_sequence.sv                  # Multiclock assertion with syntax errors
-                   doulos/35.2_export_dpi-c.sv               # Don't parse C code
-                   doulos/52.2_import_dpi-c.sv               # Don't parse C code
                    # Pulp AXI
                    pulp_axi/src/axi_demux_simple.sv     # Not supporting |-> on macro usage (line 505)
                    pulp_axi/src/axi_interleaved_xbar.sv # Preprocessing on the last parameter/port, too much effort on handling the comma
                    pulp_axi/src/axi_xbar.sv             # Preprocessing on the last parameter/port, too much effort on handling the comma
-                   #################################################################
-                   # TODO: The ones below are to be added after grammar.js cleanup #
-                   #################################################################
-                   # Let
-                   doulos/61.2_let.sv # Complex let construct, macro-like (come back if integrating $.let_expression with dynamic precedence)
-                   # Attribute
-                   doulos/8.3_attribute.sv # TODO: This one should actually work but it doesn't for some reason (doesn't detect it as a tf_call)
-                   # Conditional directives
-                   cva6/SyncDpRam.sv
-                   cva6/SyncSpRam.sv
-                   cva6/SyncSpRamBeNx32.sv
-                   cva6/SyncSpRamBeNx64.sv
-                   cva6/SyncTpRam.sv
-                   cva6/ariane_xilinx.sv
-                   cva6/riscv_core_setting.sv
-                   # Include file for enum elements
-                   cva6/riscv_custom_instr_enum.sv
-                   # Usage of keyword as function arg
-                   cva6/cva6_tb_wrapper.sv
-                   cva6/tb_dcache_pkg.sv
-                   # Complex macros (WITH, COMMA)
-                   cva6/cva6_rvfi.sv
-                   cva6/uvme_cvxif_covg.sv
-                   cva6/uvme_isa_covg.sv
-                   # Others
-                   cva6/issue_read_operands.sv # Not sure, a bit complex
-                   cva6/tb_div.sv  # for snippet detected as for generate
-                   cva6/tb_rem.sv  # for snippet detected as for generate
-                   cva6/tb_udiv.sv # for snippet detected as for generate
-                   cva6/tb_urem.sv # for snippet detected as for generate
-                   cva6/uvma_interrupt_seq.sv # Various, use of automatic in external task, dot element for time delay
-                   # TODO: No errors but missing something with tree-sitter parse/test
+                   # CVA6
+                   cva6/SyncDpRam.sv                  # Conditional directives
+                   cva6/SyncSpRam.sv                  # Conditional directives
+                   cva6/SyncSpRamBeNx32.sv            # Conditional directives
+                   cva6/SyncSpRamBeNx64.sv            # Conditional directives
+                   cva6/SyncTpRam.sv                  # Conditional directives
+                   cva6/ariane_xilinx.sv              # Conditional directives
+                   cva6/riscv_core_setting.sv         # Conditional directives
+                   cva6/riscv_custom_instr_enum.sv    # Include file for enum elements
+                   cva6/cva6_tb_wrapper.sv            # Usage of keyword as function arg
+                   cva6/tb_dcache_pkg.sv              # Usage of keyword as function arg
+                   cva6/cva6_rvfi.sv                  # Complex macros (WITH, COMMA)
+                   cva6/uvme_cvxif_covg.sv            # Complex macros (WITH, COMMA)
+                   cva6/uvme_isa_covg.sv              # Complex macros (WITH, COMMA)
+                   cva6/issue_read_operands.sv        # Not sure, a bit complex
+                   cva6/tb_div.sv                     # for snippet detected as for generate
+                   cva6/tb_rem.sv                     # for snippet detected as for generate
+                   cva6/tb_udiv.sv                    # for snippet detected as for generate
+                   cva6/tb_urem.sv                    # for snippet detected as for generate
+                   cva6/uvma_interrupt_seq.sv         # Various, use of automatic in external task, dot element for time delay
                    cva6/sram.sv                       # MISSING "always", but it's a generate!
                    cva6/uvma_cva6_core_cntrl_cntxt.sv # MISSING "end" due to pragma protects wrong detection
                    # TODO:
-                   core/bit_select/complex_4.sv
+                   sv-tests/chapter-22/22.3--resetall_illegal.sv
                    github/issue_34.sv
+                   core/bit_select/complex_4.sv
+                   core/directives/macro_2.sv         # Detects `define_var as macro definition instead of macro usage after adding directives as reserved keywords (same as sv-tests/chapter-22/22.4--check_included_definitions.sv)
+                   core/directives/macro_keyword_1.sv # reserved('macros') still not working
+                   core/directives/macro_keyword_2.sv # reserved('macros') still not working
                   )
 
 # Filter tests, if there was an argument provided


### PR DESCRIPTION
In some places where compiler directives were not legal the parser detected these as `text_macro_usage`, e.g.:
```verilog
  initial $display("At %s @ %d\n", `__FILE__, `__LINE__);
```
The grammar now properly parses the snippet as:
```
(initial_construct
  (statement_or_null
    (statement
      (statement_item
        (subroutine_call_statement
          (subroutine_call
            (system_tf_call
              (system_tf_identifier)
              (list_of_arguments
                (expression
                  (primary
                    (primary_literal
                      (string_literal
                        (quoted_string
                          (quoted_string_item)
                          (string_escape_seq))))))
                (expression
                  (file_or_line_compiler_directive))
                (expression
                  (file_or_line_compiler_directive))))))))))
```

This PR introduces breaking changes since the named nodes `(directive_*)` do not longer exist and are replaced by the directive name with a tick, e.g.:
```
(directive_ifdef)  -> `ifdef
``` 

This was needed since `tree-sitter` reserved feature requires reserved keywords being tokens.