### PR TITLE
Update multiple_concatenation to use constant_expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -3645,7 +3645,7 @@ const rules = {
   ),
 
   multiple_concatenation: $ => seq(
-    '{', $.expression, $.concatenation, '}'
+    '{', $.constant_expression, $.concatenation, '}'
   ),
 
   streaming_concatenation: $ => seq(


### PR DESCRIPTION
The SV 2017 LRM says in the footnotes:
34) In a multiple_concatenation, it shall be illegal for the multiplier not to be a constant_expression unless the type of the concatenation is string.

Therefore it makes sense to use constant_expression for the multiplier, since this is by far the more common case.